### PR TITLE
Update ppp_reconnect.sh

### DIFF
--- a/R216-Z_patch/ppp_reconnect.sh
+++ b/R216-Z_patch/ppp_reconnect.sh
@@ -11,6 +11,15 @@
 
 # Author: 2020-05-02 cosote@gmail.com
 
+check_network_status() {
+  RESULT=$(echo -ne "GET /goform/goform_get_cmd_process?cmd=ppp_status HTTP/1.0\r\nHost: 127.0.0.1\r\nReferer: http://127.0.0.1/home.htm\r\nContent-Type: application/x-www-form-urlencoded\r\n\r\n" | nc 127.0.0.1 80 | grep "ppp_disconnected")
+  if [[ "$RESULT" = '{"ppp_status":"ppp_disconnected"}' ]]; then
+    return 1
+  else
+    return 0
+  fi
+}
+
 EPOCH=0
 
 while [ 1 ]
@@ -19,15 +28,24 @@ do
    
    # Check if system was rebooted or resumed from suspension
    if [[ $(($(date +%s) - $EPOCH)) -gt 5 ]]; then
-   
-      # Check network
-      RESULT=$( echo -ne "GET /goform/goform_get_cmd_process?cmd=ppp_status HTTP/1.0\r\nHost: 127.0.0.1\r\nReferer: http://127.0.0.1/home.htm\r\nContent-Type: application/x-www-form-urlencoded\r\n\r\n" | nc 127.0.0.1 80 | grep "ppp_disconnected" )
-      
-      if [[ "$RESULT" = '{"ppp_status":"ppp_disconnected"}' ]]; then
-        # Connect network
-        BODY="goformId=CONNECT_NETWORK"
-        RESULT=$( echo -ne "POST /goform/goform_set_cmd_process HTTP/1.0\r\nHost: 127.0.0.1\r\nReferer: http://127.0.0.1/home.htm\r\nContent-Type: application/x-www-form-urlencoded\r\nContent-Length: $( echo -n ${BODY} | wc -c )\r\n\r\n${BODY}" | nc 127.0.0.1 80 )
-      fi
+
+      check_network_status
+      if [[ $? -eq 1 ]]; then
+
+         # Connect network
+         # NOTE: Occasionally it may return "{"result":"success"}" but is not true!
+         echo "Connecting..."
+         BODY="goformId=CONNECT_NETWORK"
+         RESULT=$(echo -ne "POST /goform/goform_set_cmd_process HTTP/1.0\r\nHost: 127.0.0.1\r\nReferer: http://127.0.0.1/home.htm\r\nContent-Type: application/x-www-form-urlencoded\r\nContent-Length: $(echo -n ${BODY} | wc -c)\r\n\r\n${BODY}" | nc 127.0.0.1 80)
+
+         # So, Re-check network status
+         check_network_status
+         if [[ $? -eq 1 ]]; then
+            EPOCH=0
+            continue
+         fi
+     fi
+
    fi
    
    EPOCH=$(date +%s)


### PR DESCRIPTION
On my modem, the connection command immediately returns "{"ppp_status":"ppp_disconnected"}", but the modem doesn't actually connect, and the signal light keeps flashing even after 10 minutes.

I have implemented an additional check that verifies if the modem really changes its state. 
If it doesn't change, it resets the variable EPOCH so that it can retry immediately after until it change.

Thanks for your job!